### PR TITLE
Fix #6 : basic-security-client is removed

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "node": "8.9.4"
   },
   "dependencies": {
-    "basic-security-client": "file:basic-security-client",
     "cookie-parser": "1.4.4",
     "cors": "2.8.5",
     "express": "4.17.1",


### PR DESCRIPTION
basic-security-client is removed because it is an internal npm, not public